### PR TITLE
add: missing pair hover title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -59,12 +59,12 @@
                 <use xlink:href="#homescreen" />
             </svg>
         </a>
-        <a id="pair-device" class="icon-button" >
+        <a id="pair-device" class="icon-button" title="Pair Device" >
             <svg class="icon">
                 <use xlink:href="#pair-device-icon" />
             </svg>
         </a>
-        <a id="clear-pair-devices" class="icon-button" hidden>
+        <a id="clear-pair-devices" class="icon-button" title="Unpair Device" hidden>
             <svg class="icon">
                 <use xlink:href="#clear-pair-devices-icon" />
             </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -64,7 +64,7 @@
                 <use xlink:href="#pair-device-icon" />
             </svg>
         </a>
-        <a id="clear-pair-devices" class="icon-button" title="Unpair Device" hidden>
+        <a id="clear-pair-devices" class="icon-button" title="Clear All Paired Devices" hidden>
             <svg class="icon">
                 <use xlink:href="#clear-pair-devices-icon" />
             </svg>


### PR DESCRIPTION
Currently all "action" buttons have a tooltip, while pair/unpair buttons seems to miss it.

This pull just adds the missing `title` attribute on these buttons.
