### PR TITLE
Better devicename

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
       - ./:/home/node/app
     command: ash -c "npm i && npm run start:prod"
+#    command: ash -c "npm i && npm run start:prod -- --include-ws-fallback"
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "8082:3000"
+#      - "3000:3000"

--- a/public/index.html
+++ b/public/index.html
@@ -81,11 +81,16 @@
         <p id="pasteFilename"></p>
     </x-instructions>
     <!-- Footer -->
+    <myname class="column font-body3">
+        <h2>
+            <div id="displayName" placeholder="&nbsp;"></div>
+        </h2>
+    </myname>
     <footer class="column">
         <svg class="icon logo">
             <use xlink:href="#wifi-tethering" />
         </svg>
-        <div id="displayName" placeholder="&nbsp;"></div>
+        <!--div id="displayName" placeholder="&nbsp;"></div-->
         <div class="font-body2">
             You can be discovered by everyone <span id="on-this-network">on&nbsp;this&nbsp;network</span>
             <span id="and-by-paired-devices" hidden> and&nbsp;by&nbsp;<span id="paired-devices">paired&nbsp;devices</span></span>

--- a/public/index.html
+++ b/public/index.html
@@ -81,11 +81,11 @@
         <p id="pasteFilename"></p>
     </x-instructions>
     <!-- Footer -->
-    <myname class="column font-body3">
+    <devicename class="column font-body3">
         <h2>
             <div id="displayName" placeholder="&nbsp;"></div>
         </h2>
-    </myname>
+    </devicename>
     <footer class="column">
         <svg class="icon logo">
             <use xlink:href="#wifi-tethering" />

--- a/public/scripts/network.js
+++ b/public/scripts/network.js
@@ -831,6 +831,15 @@ RTCPeer.config = {
     'sdpSemantics': 'unified-plan',
     'iceServers': [
         {
+            urls: 'stun:stun.schuerz.at:5349'
+        },
+        {
+            urls: 'turn:turn.schuerz.at:5349',
+            username: 'local',
+            credential: 'thu2aewo1iv8uFavoP8aichaiwai7zeech7o',
+        },
+      /*
+        {
             urls: 'stun:stun.l.google.com:19302'
         },
         {
@@ -841,5 +850,6 @@ RTCPeer.config = {
             username: 'openrelayproject',
             credential: 'openrelayproject',
         },
+        */
     ]
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -358,7 +358,7 @@ x-peer[drop] x-icon {
 }
 
 /* NameHeader */
-myname {
+devicename {
     position: absolute;
     top: 5%;
     left: 0;
@@ -369,7 +369,7 @@ myname {
     transition: color 300ms;
 }
 
-myname .font-body3 {
+devicename .font-body3 {
     color: var(--primary-color);
     margin: auto 32px;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -357,8 +357,22 @@ x-peer[drop] x-icon {
     transform: scale(1.1);
 }
 
+/* NameHeader */
+myname {
+    position: absolute;
+    top: 5%;
+    left: 0;
+    right: 0;
+    align-items: center;
+    padding: 0 0 16px 0;
+    text-align: center;
+    transition: color 300ms;
+}
 
-
+myname .font-body3 {
+    color: var(--primary-color);
+    margin: auto 32px;
+}
 /* Footer */
 
 footer {


### PR DESCRIPTION
The devicename in the original layout is not good to see and sometimes hidden by status-messages... ("No server connection. Retry...")

![grafik](https://user-images.githubusercontent.com/5894829/220160624-86d87075-2912-4c52-9ad4-a5de20dc62f1.png)


That is the normal Layout.
![grafik](https://user-images.githubusercontent.com/5894829/220160259-54d6a440-3b26-4ace-91d9-a62ae4aafe12.png)

I changed the position and fontsize (h1) of the devicename, so it looks like this:

![grafik](https://user-images.githubusercontent.com/5894829/220160412-719bdf7c-b98a-4a39-9b20-29cf51bf1b55.png)

It also works for smartphone-layout.
