### PR TITLE
Fix(ghcr) update workflow variable to a static lowercase name

### DIFF
--- a/.github/workflows/github-image.yml
+++ b/.github/workflows/github-image.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository | downcase }}
+  IMAGE_NAME: pairdrop
 
 jobs:
   build-and-push-image:


### PR DESCRIPTION
| downcase was not valid... so instead its a static name `pairdrop` written instead. 