### PR TITLE
Fix(ghcr) update workflow - ERROR: name invalid

### DIFF
--- a/.github/workflows/github-image.yml
+++ b/.github/workflows/github-image.yml
@@ -40,7 +40,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc


### PR DESCRIPTION
Fix error:
```log
 ------
 > pushing ghcr.io/pairdrop:v1.1.2 with docker:
------
ERROR: name invalid
Error: buildx call failed with: ERROR: name invalid
```