### PR TITLE
Updates CLI to work with OSX base64

### DIFF
--- a/pairdrop-cli/pairdrop
+++ b/pairdrop-cli/pairdrop
@@ -106,7 +106,11 @@ sendFiles()
     zip -q -b /tmp/ -r "$zipPath" "$path"
     zip -q -b /tmp/ "$zipPathTemp" "$zipPath"
 
-    hash=$(base64 -w 0 "$zipPathTemp")
+    if [[ $OS == "Mac" ]];then
+      hash=$(base64 -i "$zipPathTemp")
+    else
+      hash=$(base64 -w 0 "$zipPathTemp")
+    fi
 
     # remove temporary temp file
     rm "$zipPathTemp"
@@ -116,7 +120,11 @@ sendFiles()
     # Create zip file temporarily to send file
     zip -q -b /tmp/ "$zipPath" "$path"
 
-    hash=$(base64 -w 0 "$zipPath")
+    if [[ $OS == "Mac" ]];then
+      hash=$(base64 -i "$zipPath")
+    else
+      hash=$(base64 -w 0 "$zipPath")
+    fi
   fi
 
   # remove temporary temp file


### PR DESCRIPTION
Hi there! I tried to use the CLI on my Mac, but it turns out the script is using the `base64` command incorrectly. Here's [a link](https://www.unix.com/man-page/osx/1/base64/) to the OSX/BSD version, which uses `-b` instead of `-w` and has zero by default, but needs `-i` for the input file. Tested on OSX v13.2.1.

To test:
1. Load these changes on a Mac
2. Try to send a file via the CLI
3. Verify that files are loaded in the website as expected