### PR TITLE
fix 'file-received'-event (android app compatibility)

### DIFF
--- a/public/scripts/network.js
+++ b/public/scripts/network.js
@@ -431,14 +431,14 @@ class Peer {
 
         this.sendJSON({type: 'file-transfer-complete'});
 
-        // include for compatibility with Snapdrop for Android app
-        Events.fire('file-received');
-
         const sameSize = fileBlob.size === acceptedHeader.size;
         const sameName = fileBlob.name === acceptedHeader.name
         if (!sameSize || !sameName) {
             this._abortTransfer();
         }
+        
+        // include for compatibility with Snapdrop for Android app
+        Events.fire('file-received', fileBlob);
 
         this._filesReceived.push(fileBlob);
         if (!this._requestAccepted.header.length) {


### PR DESCRIPTION
as you can see [here](https://github.com/RobinLinus/snapdrop/blob/master/client/scripts/network.js#L206) in the snapdrop `_onFileReceived` function the 'file-received'-event needs to send the **file**  -can you try to run this on the test server, maybe this fixes the issue already :)