### PR TITLE
[POC] Change Baseimage to Distroless Node Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs:16
+FROM gcr.io/distroless/nodejs:18
 
 WORKDIR /home/node/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
-FROM gcr.io/distroless/nodejs:18
-
-WORKDIR /home/node/app
+# Prepare Nodejs Project
+FROM node:18 AS builder
 
 COPY package*.json ./
+
+WORKDIR /home/node/app
 
 RUN npm ci
 
 COPY . .
+
+# Copy build and put it in distroless Image
+
+FROM gcr.io/distroless/nodejs:18
+
+COPY --from=builder /home/node/app /home/node/app
+
+WORKDIR /home/node/app
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM gcr.io/distroless/nodejs:16
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
Hello everybody,

We have again some change ideas to make this project a bit more awesome. The current goal needs some testing, but we want to get away from alpine with its own package manager. The reason is if somebody gains access inside the container it is very likely to use the package manager and packages like wget and curl to attack your infrastructure from the inside. We want to prevent this directly by removing the possibility to add new packages.

tldr:
[POC] Reduce attack surface as there is no package manager and reduce the image size further

Further Sources:
https://snyk.io/blog/choosing-the-best-node-js-docker-image/