### PR TITLE
Fix About Background not filling up full viewport under certain circumstances

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1144,10 +1144,12 @@ button::-moz-focus-inner {
 
 #about x-background {
     position: absolute;
-    top: calc(28px - 250px);
-    right: calc(36px - 250px);
-    width: 500px;
-    height: 500px;
+    --size: max(max(23vw, 23vh), calc((22.5vh + 22.5vw) / 1.5));
+    --size-half: calc(var(--size)/2);
+    top: calc(28px - var(--size-half));
+    right: calc(36px - var(--size-half));
+    width: var(--size);
+    height: var(--size);
     border-radius: 50%;
     background: var(--primary-color);
     transform: scale(0);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1144,7 +1144,7 @@ button::-moz-focus-inner {
 
 #about x-background {
     position: absolute;
-    --size: max(max(23vw, 23vh), calc((22.5vh + 22.5vw) / 1.5));
+    --size: max(max(230vw, 230vh), calc(150vh + 150vw));
     --size-half: calc(var(--size)/2);
     top: calc(28px - var(--size-half));
     right: calc(36px - var(--size-half));
@@ -1163,7 +1163,7 @@ button::-moz-focus-inner {
 }
 
 #about:target x-background {
-    transform: scale(10);
+    transform: scale(1);
 }
 
 #about .row a {

--- a/public_included_ws_fallback/styles.css
+++ b/public_included_ws_fallback/styles.css
@@ -1170,10 +1170,12 @@ button::-moz-focus-inner {
 
 #about x-background {
     position: absolute;
-    top: calc(28px - 250px);
-    right: calc(36px - 250px);
-    width: 500px;
-    height: 500px;
+    --size: max(max(230vw, 230vh), calc(150vh + 150vw));
+    --size-half: calc(var(--size)/2);
+    top: calc(28px - var(--size-half));
+    right: calc(36px - var(--size-half));
+    width: var(--size);
+    height: var(--size);
     border-radius: 50%;
     background: var(--primary-color);
     transform: scale(0);
@@ -1187,7 +1189,7 @@ button::-moz-focus-inner {
 }
 
 #about:target x-background {
-    transform: scale(10);
+    transform: scale(1);
 }
 
 #about .row a {


### PR DESCRIPTION
It is now based on vw/vh instead of px. It can also easily be adjusted, mostly. There is no way it will not fill up the viewport. The Animation may not be the same speed anymore, but it will be consistent across devices and viewport sizes.