### PR TITLE
Add 'files-sent' event

### DIFF
--- a/public/scripts/network.js
+++ b/public/scripts/network.js
@@ -529,7 +529,7 @@ class Peer {
             this._abortTransfer();
         }
 
-        // include for compatibility with Snapdrop for Android app
+        // include for compatibility with 'Snapdrop & PairDrop for Android' app
         Events.fire('file-received', fileBlob);
 
         this._filesReceived.push(fileBlob);
@@ -547,6 +547,7 @@ class Peer {
         if (!this._filesQueue.length) {
             this._busy = false;
             Events.fire('notify-user', 'File transfer completed.');
+            Events.fire('files-sent'); // used by 'Snapdrop & PairDrop for Android' app
         } else {
             this._dequeueFile();
         }


### PR DESCRIPTION
We're planning to add vibration effects in the android app. This event would be helpful for us. See https://github.com/fm-sys/snapdrop-android/pull/299

Alternatives:
Use the HTML5 vibration API to archive this behavior natively in Pairdrop. However, vibration API is only supported by chrome, not Firefox or Safari.