### PR TITLE
Conform Docker images: Env Vars only + Automatic start

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -43,7 +43,7 @@ No | Yes
 
 **Self-Hosted Setup**
 Proxy: Nginx | Apache2
-Deployment: docker run | docker-compose | npm run start:prod
+Deployment: docker run | docker compose | npm run start:prod
 Version: v1.9.4
 
 **Additional context**

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ RUN npm ci
 
 COPY . .
 
+# environment settings
+ENV NODE_ENV="production"
+
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD wget --quiet --tries=1 --spider http://localhost:3000 || exit 1
+
+ENTRYPOINT ["node", "index.js"]

--- a/docker-compose-coturn.yml
+++ b/docker-compose-coturn.yml
@@ -1,15 +1,19 @@
 version: "3"
 services:
-  node:
-    image: "node:lts-alpine"
-    user: "node"
-    working_dir: /home/node/app
-    volumes:
-      - ./:/home/node/app
-    command: ash -c "npm i && npm run start:prod"
+  pairdrop:
+    image: "lscr.io/linuxserver/pairdrop:latest"
+    container_name: pairdrop
     restart: unless-stopped
+    environment:
+      - PUID=1000 # UID to run the application as
+      - PGID=1000 # GID to run the application as
+      - WS_FALLBACK=false # Set to true to enable websocket fallback if the peer to peer WebRTC connection is not available to the client.
+      - RATE_LIMIT=false # Set to true to limit clients to 1000 requests per 5 min.
+      - RTC_CONFIG=false # Set to the path of a file that specifies the STUN/TURN servers.
+      - DEBUG_MODE=false # Set to true to debug container and peer connections.
+      - TZ=Etc/UTC # Time Zone
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000" # Web UI. Change the port number before the last colon e.g. `127.0.0.1:9000:3000`
   coturn_server:
     image: "coturn/coturn"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
 version: "3"
 services:
-  node:
-    image: "node:lts-alpine"
-    user: "node"
-    working_dir: /home/node/app
-    volumes:
-      - ./:/home/node/app
-    command: ash -c "npm i && npm run start:prod"
+  pairdrop:
+    image: "lscr.io/linuxserver/pairdrop:latest"
+    container_name: pairdrop
     restart: unless-stopped
+    environment:
+      - PUID=1000 # UID to run the application as
+      - PGID=1000 # GID to run the application as
+      - WS_FALLBACK=false # Set to true to enable websocket fallback if the peer to peer WebRTC connection is not available to the client.
+      - RATE_LIMIT=false # Set to true to limit clients to 1000 requests per 5 min.
+      - RTC_CONFIG=false # Set to the path of a file that specifies the STUN/TURN servers.
+      - DEBUG_MODE=false # Set to true to debug container and peer connections.
+      - TZ=Etc/UTC # Time Zone
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000" # Web UI. Change the port number before the last colon e.g. `127.0.0.1:9000:3000`


### PR DESCRIPTION
This PR conforms all docker images so that there is no difference anymore in the behavior, setup and documentation of the different docker images:
- hosted on lhcr.ip
- hosted in ghcr.io
- Self-Built from repo

Additionally, the Documentation is refactored to prevent listing of the environment variables twice for deployment via Node.js and Docker.

This supersedes #186