### PR TITLE
Fix turn container files, docker-compose-coturn.yml and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -43,7 +43,7 @@ No | Yes
 
 **Self-Hosted Setup**
 Proxy: Nginx | Apache2
-Deployment: docker run | docker-compose | npm run start:prod
+Deployment: docker run | docker compose | npm run start:prod
 Version: v1.9.4
 
 **Additional context**

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 fqdn.env
 /docker/certs
 qrcode-svg/
+turnserver.conf
+rtc_config.json
+ssl/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ RUN npm ci
 
 COPY . .
 
+# environment settings
+ENV NODE_ENV="production"
+
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD wget --quiet --tries=1 --spider http://localhost:3000 || exit 1
+
+ENTRYPOINT ["node", "index.js"]

--- a/docker-compose-coturn.yml
+++ b/docker-compose-coturn.yml
@@ -1,15 +1,19 @@
 version: "3"
 services:
-  node:
-    image: "node:lts-alpine"
-    user: "node"
-    working_dir: /home/node/app
-    volumes:
-      - ./:/home/node/app
-    command: ash -c "npm i && npm run start:prod"
+  pairdrop:
+    image: "lscr.io/linuxserver/pairdrop:latest"
+    container_name: pairdrop
     restart: unless-stopped
+    environment:
+      - PUID=1000 # UID to run the application as
+      - PGID=1000 # GID to run the application as
+      - WS_FALLBACK=false # Set to true to enable websocket fallback if the peer to peer WebRTC connection is not available to the client.
+      - RATE_LIMIT=false # Set to true to limit clients to 1000 requests per 5 min.
+      - RTC_CONFIG=false # Set to the path of a file that specifies the STUN/TURN servers.
+      - DEBUG_MODE=false # Set to true to debug container and peer connections.
+      - TZ=Etc/UTC # Time Zone
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000" # Web UI. Change the port number before the last colon e.g. `127.0.0.1:9000:3000`
   coturn_server:
     image: "coturn/coturn"
     restart: always

--- a/docker-compose-coturn.yml
+++ b/docker-compose-coturn.yml
@@ -4,20 +4,28 @@ services:
     image: "lscr.io/linuxserver/pairdrop:latest"
     container_name: pairdrop
     restart: unless-stopped
+    volumes:
+      - ./rtc_config.json:/home/node/app/rtc_config.json
     environment:
       - PUID=1000 # UID to run the application as
       - PGID=1000 # GID to run the application as
       - WS_FALLBACK=false # Set to true to enable websocket fallback if the peer to peer WebRTC connection is not available to the client.
       - RATE_LIMIT=false # Set to true to limit clients to 1000 requests per 5 min.
-      - RTC_CONFIG=false # Set to the path of a file that specifies the STUN/TURN servers.
+      - RTC_CONFIG=/home/node/app/rtc_config.json # Set to the path of a file that specifies the STUN/TURN servers.
       - DEBUG_MODE=false # Set to true to debug container and peer connections.
       - TZ=Etc/UTC # Time Zone
     ports:
       - "127.0.0.1:3000:3000" # Web UI. Change the port number before the last colon e.g. `127.0.0.1:9000:3000`
   coturn_server:
     image: "coturn/coturn"
-    restart: always
-    network_mode: "host"
+    restart: unless-stopped
     volumes:
       - ./turnserver.conf:/etc/coturn/turnserver.conf
-    #you need to copy turnserver_example.conf to turnserver.conf and specify domain, IP address, user and password
+      - ./ssl/:/etc/coturn/ssl/
+    ports:
+      - "3478:3478"
+      - "3478:3478/udp"
+      - "5349:5349"
+      - "5349:5349/udp"
+      - "10000-20000:10000-20000/udp"
+    # see guide at docs/host-your-own.md#coturn-and-pairdrop-via-docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
 version: "3"
 services:
-  node:
-    image: "node:lts-alpine"
-    user: "node"
-    working_dir: /home/node/app
-    volumes:
-      - ./:/home/node/app
-    command: ash -c "npm i && npm run start:prod"
+  pairdrop:
+    image: "lscr.io/linuxserver/pairdrop:latest"
+    container_name: pairdrop
     restart: unless-stopped
+    environment:
+      - PUID=1000 # UID to run the application as
+      - PGID=1000 # GID to run the application as
+      - WS_FALLBACK=false # Set to true to enable websocket fallback if the peer to peer WebRTC connection is not available to the client.
+      - RATE_LIMIT=false # Set to true to limit clients to 1000 requests per 5 min.
+      - RTC_CONFIG=false # Set to the path of a file that specifies the STUN/TURN servers.
+      - DEBUG_MODE=false # Set to true to debug container and peer connections.
+      - TZ=Etc/UTC # Time Zone
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000" # Web UI. Change the port number before the last colon e.g. `127.0.0.1:9000:3000`

--- a/docs/host-your-own.md
+++ b/docs/host-your-own.md
@@ -6,6 +6,8 @@ Beware that you have to host your own TURN server to enable transfers between di
 
 Follow [this guide](https://gabrieltanner.org/blog/turn-server/) to either install coturn directly on your system (Step 1) 
 or deploy it via Docker (Step 5).
+
+You can use the `docker-compose-coturn.yml` in this repository. See [Coturn and PairDrop via Docker Compose](#coturn-and-pairdrop-via-docker-compose).
  
 Alternatively, use a free, pre-configured TURN server like [OpenRelay](https://www.metered.ca/tools/openrelay/)
 
@@ -543,6 +545,54 @@ a2ensite pairdrop
 ```bash
 service apache2 reload
 ```
+
+<br>
+
+## Coturn and PairDrop via Docker Compose
+
+### Setup container
+To run coturn and PairDrop at once by using the `docker-compose-coturn.yml` with TURN over TLS enabled
+you need to follow these steps:
+
+1. Generate or retrieve certificates for your `<DOMAIN>` (e.g. letsencrypt / certbot)
+2. Create `./ssl` folder: `mkdir ssl`
+3. Copy your ssl-certificates and the privkey to `./ssl` 
+4. Restrict access to `./ssl`: `chown -R nobody:nogroup ./ssl`
+5. Create a dh-params file: `openssl dhparam -out ./ssl/dhparams.pem 4096` 
+6. Copy `rtc_config_example.json` to `rtc_config.json`
+7. Copy `turnserver_example.conf` to `turnserver.conf`
+8. Change `<DOMAIN>` in both files to the domain where your PairDrop instance is running 
+9. Change `username` and `password` in `turnserver.conf` and `rtc-config.json`
+10. To start the container including coturn run: \
+  `docker compose -f docker-compose-coturn.yml up -d`
+
+<br>
+
+#### Setup container
+To restart the container including coturn run: \
+  `docker compose -f docker-compose-coturn.yml restart`
+
+<br>
+
+#### Setup container
+To stop the container including coturn run: \
+  `docker compose -f docker-compose-coturn.yml stop`
+
+<br>
+
+### Firewall
+To run PairDrop including its own coturn-server you need to punch holes in the firewall. These ports must be opened additionally:
+- 3478 tcp/udp
+- 5349 tcp/udp
+- 10000:20000 tcp/udp
+
+<br>
+
+### Firewall
+To run PairDrop including its own coturn-server you need to punch holes in the firewall. These ports must be opened additionally:
+- 3478 tcp/udp
+- 5349 tcp/udp
+- 10000:20000 tcp/udp
 
 <br>
 

--- a/rtc_config_example.json
+++ b/rtc_config_example.json
@@ -2,10 +2,10 @@
   "sdpSemantics": "unified-plan",
   "iceServers": [
     {
-      "urls": "stun:stun.l.google.com:19302"
+      "urls": "stun:<DOMAIN>:3478"
     },
     {
-      "urls": "turn:example.com:3478",
+      "urls": "turns:<DOMAIN>:5349",
       "username": "username",
       "credential": "password"
     }

--- a/turnserver_example.conf
+++ b/turnserver_example.conf
@@ -6,10 +6,15 @@ server-name=pairdrop
 listening-ip=0.0.0.0
 
 # External IP-Address of the TURN server
-external-ip=<IP_ADDRESS>
+# only needed, if coturn is behind a NAT
+# external-ip=<IP_ADDRESS>
 
-# Main listening port
+# Main listening port for STUN and TURN
 listening-port=3478
+
+# Main listening port for TURN over TLS (TURNS)
+# Use port 443 to bypass some firewalls
+tls-listening-port=5349
 
 # Further ports that are open for communication
 min-port=10000
@@ -18,21 +23,34 @@ max-port=20000
 # Use fingerprint in TURN message
 fingerprint
 
-# Log file path
-log-file=/var/log/turnserver.log
-
 # Enable verbose logging
-verbose
+# verbose
+
+# Log file path
+# - is logging to STDOUT, so it's visible in docker-compose logs
+log-file=-
 
 # Specify the user for the TURN authentification
-user=user:password
+user=username:password
 
 # Enable long-term credential mechanism
 lt-cred-mech
 
 # SSL certificates
-cert=/etc/letsencrypt/live/<DOMAIN>/cert.pem
-pkey=/etc/letsencrypt/live/<DOMAIN>/privkey.pem
+cert=/etc/coturn/ssl/cert.crt
+pkey=/etc/coturn/ssl/pkey.pem
+dh-file=/etc/coturn/ssl/dhparam.pem
 
-# 443 for TURN over TLS, which can bypass firewalls
-tls-listening-port=443
+# For security-reasons disable old ssl and tls-protocols
+# and other recommended options: see https://github.com/coturn/coturn/blob/master/examples/etc/turnserver.conf
+no-sslv3
+no-tlsv1
+no-tlsv1_1
+no-tlsv1_2
+no-rfc5780
+no-stun-backward-compatibility
+response-origin-only-with-rfc5780
+no-cli
+no-multicast-peers
+no-software-attribute
+check-origin-consistency


### PR DESCRIPTION
Partly supersedes (and cherry-picked from) #106.

@xundeenergie, I have rebased and combined some of your changes into this to offer users a working example out of the box and added you as co-author. 

As multiple users have had difficulties with PairDrop running without a TURN server I conformed the docker images (#194). This PR adds working compose files and your guide to easily deploy PairDrop alongside Coturn and integrate the changes into the new documentation.

It focuses on simplicity, so TURN over TLS runs on a separate port and not on 443. If you want to further investigate the possibility via nginx and upstreams or the use of another authentication method feel free to do so over at #106!

If you got some time on your hands, I’d appreciate it if you could quickly test whether everything works as expected before I merge this into master!

Thanks again for your contribution!