### PR TITLE
Fix Error Invalid Group Specifier Name on Safari

### DIFF
--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -2019,8 +2019,8 @@ class ReceiveTextDialog extends Dialog {
         if (text.length < 2000) {
             // replace URLs with actual links
             this.$text.innerHTML = this.$text.innerHTML
-                .replace(/(^|(?<=(<br>|\s)))(https?:\/\/|www.)(([a-z]|[A-Z]|[0-9]|[\-_~:\/?#\[\]@!$&'()*+,;=%]){2,}\.)(([a-z]|[A-Z]|[0-9]|[\-_~:\/?#\[\]@!$&'()*+,;=%.]){2,})/g,
-                (url) => {
+                .replace(/(^|<br>|\s|")((https?:\/\/|www.)(([a-z]|[A-Z]|[0-9]|[\-_~:\/?#\[\]@!$&'()*+,;=%]){2,}\.)(([a-z]|[A-Z]|[0-9]|[\-_~:\/?#\[\]@!$&'()*+,;=%.]){2,}))/g,
+                (match, whitespace, url) => {
                         let link = url;
 
                         // prefix www.example.com with http protocol to prevent it from being a relative link
@@ -2028,7 +2028,13 @@ class ReceiveTextDialog extends Dialog {
                             link = "http://" + link
                         }
 
-                        return `<a href="${link}" target="_blank">${url}</a>`;
+                        // Check if link is valid
+                        if (isUrlValid(link)) {
+                            return `${whitespace}<a href="${link}" target="_blank">${url}</a>`;
+                        }
+                        else {
+                            return match;
+                        }
                 });
         }
 

--- a/public/scripts/util.js
+++ b/public/scripts/util.js
@@ -584,3 +584,13 @@ async function decodeBase64Text(base64) {
 
     return decodeURIComponent(escape(window.atob(base64)))
 }
+
+function isUrlValid(url) {
+    try {
+        let urlObj = new URL(url);
+        return true;
+    }
+    catch (e) {
+        return false;
+    }
+}


### PR DESCRIPTION
Fix Error Invalid Group Specifier Name on Safari by removing REGEX lookbehind group construct (fixes #239 and fixes #246)