### PR TITLE
Fix buttons hover effect - issue #262

### DIFF
--- a/public/styles/styles-main.css
+++ b/public/styles/styles-main.css
@@ -626,7 +626,6 @@ x-dialog:not([show]) x-background {
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: -1;
     opacity: 0;
     background-color: var(--accent-color);
     transition: opacity 300ms;


### PR DESCRIPTION
It appears that the bug is resolved by removing the `z-index: -1` line.

I've made tests on both Chrome and Firefox, and the hover effect is now functioning correctly without any observed side effects.

issue link: #262 

![image](https://github.com/schlagmichdoch/PairDrop/assets/98855058/0e1565d4-6228-4bba-95ea-e91fb7c677c7)
