### PR TITLE
Removed duplicate feature in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Send a file from your phone to your laptop?
 * Connect to devices in complex network environments (public Wi-Fi, company network, iCloud Private Relay, VPN, etc.).
 * Connect to devices on your mobile hotspot.
 * Devices outside of your local network that are behind a NAT are auto-connected via the PairDrop TURN server.
-* Connect to devices on your mobile hotspot.
 * Devices from the local network, in the same public room, or previously paired are shown.
 
 #### Persistent Device Pairing


### PR DESCRIPTION
In the "Differences to the Snapdrop" > "Paired Devices Public Rooms" section, the following feature was repeated twice:

"Connect to devices on your mobile hotspot" (in bullet 3 and 4)

This pull request aims to fix it.