### PR TITLE
Fix inner text being cleared when viewing next received text from queue

### DIFF
--- a/public/scripts/ui.js
+++ b/public/scripts/ui.js
@@ -2147,7 +2147,6 @@ class ReceiveTextDialog extends Dialog {
         super.hide();
         setTimeout(() => {
             this._dequeueRequests();
-            this.$text.innerHTML = "";
         }, 500);
     }
 }


### PR DESCRIPTION
Fixes a bug where ReceiveDialog text contents are empty when loading another request from the queue.

Before:

https://github.com/schlagmichdoch/PairDrop/assets/47790222/f08655c8-0529-4d28-932a-be222444351c

After:

https://github.com/schlagmichdoch/PairDrop/assets/47790222/dbfdc776-f12e-4a0e-aab0-8f5cdb8aaa34

From my understanding, `_dequeueRequests` already handles the possibility of there not being any messages in the queue in here:
```ts
    _dequeueRequests() {
        if (!this._receiveTextQueue.length) {
            this.$text.innerHTML = "";
            return;
        }
```

The line removed in this PR always clears the `innerHTML`, regardless of if there are any messages in the queue, which leads to `$text` being empty when viewing next message from the queue.
