### PR TITLE
Fixed typo in rtc_config_example.json

### DIFF
--- a/rtc_config_example.json
+++ b/rtc_config_example.json
@@ -5,7 +5,7 @@
       "urls": "stun:<DOMAIN>:3478"
     },
     {
-      "urls": "turns:<DOMAIN>:5349",
+      "urls": "turn:<DOMAIN>:5349",
       "username": "username",
       "credential": "password"
     }


### PR DESCRIPTION
"urls": "turns:<DOMAIN>:5349" changed to
"urls": "turn:<DOMAIN>:5349"

This little oversight costed me a few hours of my life I'll never get back. :)