### PR TITLE
Remove bar at top of screen on iOS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
     <meta name="theme-color" content="#3367d6">
     <meta name="color-scheme" content="dark light">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="PairDrop">
     <meta name="application-name" content="PairDrop">
     <!-- Descriptions -->


### PR DESCRIPTION
On iOS, when the app runs as a PWA without this line, there will be a blue bar at the top of the screen. Implementing this setting will make for a more seamless UI on iOS, as documented below.

https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html

Before `apple-mobile-web-app-status-bar-style`:
![Without Commit_Dark](https://github.com/user-attachments/assets/5670d938-1307-4b26-8d65-559cef4170ff)![Without Commit_Light](https://github.com/user-attachments/assets/bc9f4d71-16bd-4b9f-bab9-3b263a44dcbb)


After `apple-mobile-web-app-status-bar-style`:
![With Commit_Dark](https://github.com/user-attachments/assets/01eb4be3-0e76-468b-bd02-07da29fb851e) ![With Commit_Light](https://github.com/user-attachments/assets/94963d39-53b7-4bd0-94c9-9339cd84842f)