### PR TITLE
Restore desktop Chrome PWA button

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,6 +26,7 @@
         }
     ],
     "background_color": "#efefef",
+    "start_url": "/",
     "display": "standalone",
     "theme_color": "#3367d6",
     "screenshots" : [

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -26,7 +26,7 @@
         }
     ],
     "background_color": "#efefef",
-    "start_url": "/",
+    "start_url": "./",
     "display": "standalone",
     "theme_color": "#3367d6",
     "screenshots" : [


### PR DESCRIPTION
It looks like with the last update, the PWA install button in Chrome-based browsers no longer appears. Adding the `start_url`  line resolves this and restores that functionality. This change also retains the PWA functionality we expect on mobile devices, as tested on my iPhone.