### PR TITLE
Support TURN config via env var instead of a committed file

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,15 @@ process.on('unhandledRejection', (reason, promise) => {
     console.log(reason)
 })
 
+// Allow supplying the STUN/TURN config as the raw JSON content of an env
+// var (TURN_CONFIG_JSON) instead of a file committed to the repo, since this
+// repo is public and TURN credentials must never be committed to it.
+if (process.env.TURN_CONFIG_JSON && !process.env.RTC_CONFIG) {
+    const tmpConfigPath = "/tmp/rtc_config.json";
+    fs.writeFileSync(tmpConfigPath, process.env.TURN_CONFIG_JSON);
+    process.env.RTC_CONFIG = tmpConfigPath;
+}
+
 // Evaluate arguments for deployment with Docker and Node.js
 let conf = {};
 


### PR DESCRIPTION
RTC_CONFIG currently expects a file path, which means deploying with a custom TURN server requires committing TURN credentials into the repo (or maintaining an untracked file on the server manually).

This adds `TURN_CONFIG_JSON`: if set (and `RTC_CONFIG` isn't), its raw JSON content is written to `/tmp/rtc_config.json` at startup and `RTC_CONFIG` is pointed at it. This lets credentials live only in the platform's env var storage (e.g. Render, Railway, Docker secrets) instead of the filesystem/repo.

Verified end-to-end (env var -> file -> parsed rtcConfig -> served correctly over the ws-config message) with a local run before deploying my own fork.